### PR TITLE
Add progress percentage indicators when downloading extensions 

### DIFF
--- a/extensions/postinstall.mjs
+++ b/extensions/postinstall.mjs
@@ -14,12 +14,21 @@ function processRoot() {
 		'lib',
 		'package.json',
 	]);
+
+	let index = 0;
+    	const totalFiles = fs.readdirSync(root).length;
+
 	for (const name of fs.readdirSync(root)) {
 		if (!toKeep.has(name)) {
 			const filePath = path.join(root, name);
 			console.log(`Removed ${filePath}`);
 			fs.rmSync(filePath, { recursive: true });
+
 		}
+		index++;
+		console.log(`Progress: ${(index / totalFiles * 100).toFixed(2)}%`);
+
+
 	}
 }
 
@@ -30,7 +39,8 @@ function processLib() {
 	]);
 
 	const libRoot = path.join(root, 'lib');
-
+	
+    	let index = 0;
 	for (const name of fs.readdirSync(libRoot)) {
 		if (name === 'lib.d.ts' || name.match(/^lib\..*\.d\.ts$/) || name === 'protocol.d.ts') {
 			continue;
@@ -48,6 +58,10 @@ function processLib() {
 				console.warn(e);
 			}
 		}
+		index++;
+		console.log(`Progress: ${(index / totalFiles * 100).toFixed(2)}%`);
+
+
 	}
 }
 


### PR DESCRIPTION
Implementation of a progress tracker for the `processRoot` and `processLib` functions in 'postinstall.mjs' by adding console log statements to display progress as a percentage when installing extensions to help improve user feedback. This should show up as updates regarding the completion status of the installation of a VSCode extension, and the percentage should be accurately based on the progress of the installation.

To help resolve the following issue:
https://github.com/microsoft/vscode/issues/224365

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
